### PR TITLE
Support queries for MongoDB subdocuments in arrays via query string 

### DIFF
--- a/dead_simple_framework/api/utils.py
+++ b/dead_simple_framework/api/utils.py
@@ -110,7 +110,7 @@ def parse_query_pairs(payload: str) -> dict:
     '''
 
     pairs = {}
-    for pair_tuple in map(lambda pair: re.split(r":(?![^{]*})", pair), [pair for pair in re.split(r",+(?![^([|{)]*(\]|}))", payload)]):
+    for pair_tuple in map(lambda pair: re.split(r":(?![^{]*})", pair), [pair for pair in re.split(r",+(?![^([|{)]*(\]|}))", payload) if pair]):
         params = normalize_query_string(pair_tuple[1])
         normalized_ops = normalize_op_params(pair_tuple[0], params)
         if isinstance(normalized_ops, (str, bool)):

--- a/dead_simple_framework/api/utils.py
+++ b/dead_simple_framework/api/utils.py
@@ -83,6 +83,16 @@ def normalize_op_params(field:str, op_string:str) -> dict:
             {field: param} for param in or_params
         ]}
 
+    if op_string[0] == '{' and op_string[-1] == '}':
+        inner_data = op_string[1:-1] 
+        params = inner_data.split(',')
+        data = {}
+        for param in params:
+            split_params = param.split(':')
+            data[split_params[0]] = split_params[1].replace("%20", " ")
+
+        return {field: {"$elemMatch": data}}
+
     if op_string.capitalize() == 'False':
         return False
     elif op_string.capitalize() == 'True':
@@ -100,7 +110,7 @@ def parse_query_pairs(payload: str) -> dict:
     '''
 
     pairs = {}
-    for pair_tuple in map(lambda pair: pair.split(':'), [pair for pair in re.split(r",+(?![^[]*\])", payload)]):
+    for pair_tuple in map(lambda pair: re.split(r":(?![^{]*})", pair), [pair for pair in re.split(r",+(?![^([|{)]*(\]|}))", payload)]):
         params = normalize_query_string(pair_tuple[1])
         normalized_ops = normalize_op_params(pair_tuple[0], params)
         if isinstance(normalized_ops, (str, bool)):

--- a/dead_simple_framework/config/schema.py
+++ b/dead_simple_framework/config/schema.py
@@ -47,22 +47,25 @@ class SchemaHandler:
         return path_name
 
 
-    def validate_request(self, route:str, method:str, request:dict):
+    def validate_request(self, route:str, method:str, request:dict, throw_errors=False):
         ''' Validate a request against the provided schema '''
 
         if method in self.schema:
             method_schema = self.schema[method].copy()
             if 'redact' in method_schema: method_schema.pop('redact')
             if 'filter' in request: request.update(request.pop('filter'))
-            for op in ['$and', '$or']:
+            for op in ['$and', '$or', "$elemMatch"]:
                 if op in request:
                     for chunk in request[op]:
-                        self.validate_request(route, method, chunk)
+                        self.validate_request(route, method, chunk, True)
                     return True
 
             try:
                 validate(request, method_schema)
             except ValidationError as e:
+                if throw_errors:
+                    raise e
+
                 raw_path = self.parse_path(e)
                 error_data = {
                     'error': 'Schema validation error',

--- a/dead_simple_framework/config/schema.py
+++ b/dead_simple_framework/config/schema.py
@@ -58,7 +58,7 @@ class SchemaHandler:
                 if op in request:
                     for chunk in request[op]:
                         self.validate_request(route, method, chunk, True)
-                    return True
+                    return False
 
             try:
                 validate(request, method_schema)

--- a/pypi/setup.py
+++ b/pypi/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     name='dead_simple_framework',
     license="MIT",
     description='RESTful Flask framework with builtin MongoDB, Redis, Celery, Sentry and Slack integrations',
-    version='v1.2.9',
+    version='v1.3.0',
     long_description=README,
     url='https://github.com/Topazoo/dead_simple_framework',
     packages=setuptools.find_packages(),

--- a/pypi/setup.py
+++ b/pypi/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     name='dead_simple_framework',
     license="MIT",
     description='RESTful Flask framework with builtin MongoDB, Redis, Celery, Sentry and Slack integrations',
-    version='v1.3.0',
+    version='v1.3.1',
     long_description=README,
     url='https://github.com/Topazoo/dead_simple_framework',
     packages=setuptools.find_packages(),

--- a/pypi/setup.py
+++ b/pypi/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     name='dead_simple_framework',
     license="MIT",
     description='RESTful Flask framework with builtin MongoDB, Redis, Celery, Sentry and Slack integrations',
-    version='v1.2.8',
+    version='v1.2.9',
     long_description=README,
     url='https://github.com/Topazoo/dead_simple_framework',
     packages=setuptools.find_packages(),

--- a/pypi/setup.py
+++ b/pypi/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     name='dead_simple_framework',
     license="MIT",
     description='RESTful Flask framework with builtin MongoDB, Redis, Celery, Sentry and Slack integrations',
-    version='v1.3.1',
+    version='v1.3.2',
     long_description=README,
     url='https://github.com/Topazoo/dead_simple_framework',
     packages=setuptools.find_packages(),


### PR DESCRIPTION
Allows https://docs.mongodb.com/manual/tutorial/query-embedded-documents/ via a query string like:
```
/endpoint?filter=document.subdocument:{name:Test,parent:super}
```